### PR TITLE
Rename SoftSide Apple 2 covertapes

### DIFF
--- a/TOSEC/Apple II - Covertapes.dat
+++ b/TOSEC/Apple II - Covertapes.dat
@@ -12,76 +12,76 @@
 		<homepage>TOSEC</homepage>
 		<url>http://www.tosecdev.org/</url>
 	</header>
-	<game name="SoftSide Issue 30 (19xx)(SoftSide Publications)(US)">
-		<description>SoftSide Issue 30 (19xx)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide Issue 30 (19xx)(SoftSide Publications)(US).wav" size="5479212" crc="4c4363e4" md5="331e506855044d6dc56ea2d69d5d0fe8" sha1="f3cd6557ed709c13555b0cc67091fdbf40026104"/>
+	<game name="SoftSide v03n04 (1981-01)(SoftSide Publications)(US)">
+		<description>SoftSide v03n04 (1981-01)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v03n04 (1981-01)(SoftSide Publications)(US).wav" size="5843564" crc="f61e8c06" md5="629b6dbbf31c2041fb6e69f330db2b72" sha1="087e7c8dfe0985c47c4781cb30d7d87acf58cc15"/>
 	</game>
-	<game name="SoftSide Issue 31 (19xx)(SoftSide Publications)(US)">
-		<description>SoftSide Issue 31 (19xx)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide Issue 31 (19xx)(SoftSide Publications)(US).wav" size="3550764" crc="6ae8be1c" md5="237353f53465255ad136ccd2909ea822" sha1="b712888c96329b2c3c9a0c50b2bac98d4b784e5e"/>
+	<game name="SoftSide v03n05 (1981-02)(SoftSide Publications)(US)">
+		<description>SoftSide v03n05 (1981-02)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v03n05 (1981-02)(SoftSide Publications)(US).wav" size="4176684" crc="173254c9" md5="73ab6a177d01e0ca77fad3c22c90a308" sha1="c28ff963283f43ee9fa723ac493698e3e55e3b8a"/>
 	</game>
-	<game name="SoftSide v3n4 (1981-01)(SoftSide Publications)(US)">
-		<description>SoftSide v3n4 (1981-01)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v3n4 (1981-01)(SoftSide Publications)(US).wav" size="5843564" crc="f61e8c06" md5="629b6dbbf31c2041fb6e69f330db2b72" sha1="087e7c8dfe0985c47c4781cb30d7d87acf58cc15"/>
+	<game name="SoftSide v03n06 (1981-03)(SoftSide Publications)(US)">
+		<description>SoftSide v03n06 (1981-03)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v03n06 (1981-03)(SoftSide Publications)(US).wav" size="4605484" crc="0ab08fc1" md5="ecaea9082059cc123e5e2f2e609255ce" sha1="f0301ed7b63ec2efe740ee0b1371a12acfd616fe"/>
 	</game>
-	<game name="SoftSide v3n5 (1981-02)(SoftSide Publications)(US)">
-		<description>SoftSide v3n5 (1981-02)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v3n5 (1981-02)(SoftSide Publications)(US).wav" size="4176684" crc="173254c9" md5="73ab6a177d01e0ca77fad3c22c90a308" sha1="c28ff963283f43ee9fa723ac493698e3e55e3b8a"/>
+	<game name="SoftSide v03n07 (1981-04)(SoftSide Publications)(US)">
+		<description>SoftSide v03n07 (1981-04)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v03n07 (1981-04)(SoftSide Publications)(US).wav" size="5597484" crc="2b27bbfb" md5="3f5fccb8a975607c9523840d6de08694" sha1="b09e21254756b9e6394b63cfd36c614a1d86ce44"/>
 	</game>
-	<game name="SoftSide v3n6 (1981-03)(SoftSide Publications)(US)">
-		<description>SoftSide v3n6 (1981-03)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v3n6 (1981-03)(SoftSide Publications)(US).wav" size="4605484" crc="0ab08fc1" md5="ecaea9082059cc123e5e2f2e609255ce" sha1="f0301ed7b63ec2efe740ee0b1371a12acfd616fe"/>
+	<game name="SoftSide v03n08 (1981-05)(SoftSide Publications)(US)">
+		<description>SoftSide v03n08 (1981-05)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v03n08 (1981-05)(SoftSide Publications)(US).wav" size="5401388" crc="2f094a6f" md5="5c7dbf52e1c9cc9bc04ac0cabd83c882" sha1="56e82ec918add2cdd41e85670e43fd8bdd5bffbb"/>
 	</game>
-	<game name="SoftSide v3n7 (1981-04)(SoftSide Publications)(US)">
-		<description>SoftSide v3n7 (1981-04)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v3n7 (1981-04)(SoftSide Publications)(US).wav" size="5597484" crc="2b27bbfb" md5="3f5fccb8a975607c9523840d6de08694" sha1="b09e21254756b9e6394b63cfd36c614a1d86ce44"/>
+	<game name="SoftSide v04n09 (1981-06)(SoftSide Publications)(US)">
+		<description>SoftSide v04n09 (1981-06)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v04n09 (1981-06)(SoftSide Publications)(US).wav" size="4574764" crc="9eece719" md5="aaa6fc8b55b6975c194f1c17133123d6" sha1="ba935c3783bbb038856a7afd6dfacb6d5fa0f2dc"/>
 	</game>
-	<game name="SoftSide v3n8 (1981-05)(SoftSide Publications)(US)">
-		<description>SoftSide v3n8 (1981-05)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v3n8 (1981-05)(SoftSide Publications)(US).wav" size="5401388" crc="2f094a6f" md5="5c7dbf52e1c9cc9bc04ac0cabd83c882" sha1="56e82ec918add2cdd41e85670e43fd8bdd5bffbb"/>
+	<game name="SoftSide v04n10 (1981-07)(SoftSide Publications)(US)">
+		<description>SoftSide v04n10 (1981-07)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v04n10 (1981-07)(SoftSide Publications)(US).wav" size="6104364" crc="b2487dc2" md5="7cbadfdfc7d26d838efc722cc708b3cd" sha1="b756b3b6740af14bbb798312ee4fcb5ccf2ae81f"/>
 	</game>
-	<game name="SoftSide v4n10 (1981-07)(SoftSide Publications)(US)">
-		<description>SoftSide v4n10 (1981-07)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v4n10 (1981-07)(SoftSide Publications)(US).wav" size="6104364" crc="b2487dc2" md5="7cbadfdfc7d26d838efc722cc708b3cd" sha1="b756b3b6740af14bbb798312ee4fcb5ccf2ae81f"/>
+	<game name="SoftSide v04n11 (1981-08)(SoftSide Publications)(US)">
+		<description>SoftSide v04n11 (1981-08)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v04n11 (1981-08)(SoftSide Publications)(US).wav" size="7275564" crc="f3b26e1a" md5="a5d17c774d9ac11fe3485bed4cfddff3" sha1="c8c1e18c2eedb12916ea960550bc89f1a28d6a6a"/>
 	</game>
-	<game name="SoftSide v4n11 (1981-08)(SoftSide Publications)(US)">
-		<description>SoftSide v4n11 (1981-08)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v4n11 (1981-08)(SoftSide Publications)(US).wav" size="7275564" crc="f3b26e1a" md5="a5d17c774d9ac11fe3485bed4cfddff3" sha1="c8c1e18c2eedb12916ea960550bc89f1a28d6a6a"/>
+	<game name="SoftSide v04n12 (1981-09)(SoftSide Publications)(US)">
+		<description>SoftSide v04n12 (1981-09)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v04n12 (1981-09)(SoftSide Publications)(US).wav" size="5331244" crc="c9d327dc" md5="03c1a112815955389de8bb2c0b6fe1ac" sha1="e9e06b885612dc051798f55c0268a3ceaae3357a"/>
 	</game>
-	<game name="SoftSide v4n12 (1981-09)(SoftSide Publications)(US)">
-		<description>SoftSide v4n12 (1981-09)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v4n12 (1981-09)(SoftSide Publications)(US).wav" size="5331244" crc="c9d327dc" md5="03c1a112815955389de8bb2c0b6fe1ac" sha1="e9e06b885612dc051798f55c0268a3ceaae3357a"/>
+	<game name="SoftSide v05n01 (1981-10)(SoftSide Publications)(US)">
+		<description>SoftSide v05n01 (1981-10)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n01 (1981-10)(SoftSide Publications)(US).wav" size="2868780" crc="9c2f08f0" md5="2a6a2b2ee9dfa573bae24ce67252f1d5" sha1="bc22110a5c500fffaada03b88a6a00dddbf0798d"/>
 	</game>
-	<game name="SoftSide v4n9 (1981-06)(SoftSide Publications)(US)">
-		<description>SoftSide v4n9 (1981-06)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v4n9 (1981-06)(SoftSide Publications)(US).wav" size="4574764" crc="9eece719" md5="aaa6fc8b55b6975c194f1c17133123d6" sha1="ba935c3783bbb038856a7afd6dfacb6d5fa0f2dc"/>
+	<game name="SoftSide v05n03 (1981-12)(SoftSide Publications)(US)">
+		<description>SoftSide v05n03 (1981-12)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n03 (1981-12)(SoftSide Publications)(US).wav" size="4618284" crc="956dcc21" md5="d7c3f8f0f13d40f3e1edc0f35fa95a99" sha1="a671cc9977683b6fb3b4602b34d82e96d6467d36"/>
 	</game>
-	<game name="SoftSide v5n1 (1981-10)(SoftSide Publications)(US)">
-		<description>SoftSide v5n1 (1981-10)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v5n1 (1981-10)(SoftSide Publications)(US).wav" size="2868780" crc="9c2f08f0" md5="2a6a2b2ee9dfa573bae24ce67252f1d5" sha1="bc22110a5c500fffaada03b88a6a00dddbf0798d"/>
+	<game name="SoftSide v05n04 (1982-01)(SoftSide Publications)(US)">
+		<description>SoftSide v05n04 (1982-01)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n04 (1982-01)(SoftSide Publications)(US).wav" size="6637356" crc="641c6c21" md5="19cdc6ea15599cb0f6940683056cddce" sha1="ac55561bdf2f566507dd5325377598bf2d0e7b66"/>
 	</game>
-	<game name="SoftSide v5n3 (1981-12)(SoftSide Publications)(US)">
-		<description>SoftSide v5n3 (1981-12)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v5n3 (1981-12)(SoftSide Publications)(US).wav" size="4618284" crc="956dcc21" md5="d7c3f8f0f13d40f3e1edc0f35fa95a99" sha1="a671cc9977683b6fb3b4602b34d82e96d6467d36"/>
+	<game name="SoftSide v05n05 (1982-02)(SoftSide Publications)(US)">
+		<description>SoftSide v05n05 (1982-02)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n05 (1982-02)(SoftSide Publications)(US).wav" size="4651564" crc="bb91e0e2" md5="dcd2af47025ef94d90ada4abde31e52b" sha1="a6d0c2db30592b3a11ff7a28746bf8917af71ec6"/>
 	</game>
-	<game name="SoftSide v5n4 (1982-01)(SoftSide Publications)(US)">
-		<description>SoftSide v5n4 (1982-01)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v5n4 (1982-01)(SoftSide Publications)(US).wav" size="6637356" crc="641c6c21" md5="19cdc6ea15599cb0f6940683056cddce" sha1="ac55561bdf2f566507dd5325377598bf2d0e7b66"/>
+	<game name="SoftSide v05n06 (1982-03)(SoftSide Publications)(US)">
+		<description>SoftSide v05n06 (1982-03)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n06 (1982-03)(SoftSide Publications)(US).wav" size="3936044" crc="1e013bac" md5="54f77433bed25c580514b065340a9318" sha1="92f0daf8b3c25986432eade4e422b7c36b42030a"/>
 	</game>
-	<game name="SoftSide v5n5 (1982-02)(SoftSide Publications)(US)">
-		<description>SoftSide v5n5 (1982-02)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v5n5 (1982-02)(SoftSide Publications)(US).wav" size="4651564" crc="bb91e0e2" md5="dcd2af47025ef94d90ada4abde31e52b" sha1="a6d0c2db30592b3a11ff7a28746bf8917af71ec6"/>
+	<game name="SoftSide v05n07 (1982-04)(SoftSide Publications)(US)">
+		<description>SoftSide v05n07 (1982-04)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n07 (1982-04)(SoftSide Publications)(US).wav" size="6144044" crc="098d3b73" md5="841539781a5cd16add16fe0e0aaf75e0" sha1="4147d4b8c4fee6abfae297e3d507ebff7960f89a"/>
 	</game>
-	<game name="SoftSide v5n6 (1982-03)(SoftSide Publications)(US)">
-		<description>SoftSide v5n6 (1982-03)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v5n6 (1982-03)(SoftSide Publications)(US).wav" size="3936044" crc="1e013bac" md5="54f77433bed25c580514b065340a9318" sha1="92f0daf8b3c25986432eade4e422b7c36b42030a"/>
+	<game name="SoftSide v05n08 (1982-05)(SoftSide Publications)(US)">
+		<description>SoftSide v05n08 (1982-05)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n08 (1982-05)(SoftSide Publications)(US).wav" size="5369900" crc="fecbafe4" md5="a2d63f17ab26d25ce515fa36d69e9e06" sha1="d22ddcf09fb9d2793c9227f7abcdcfab46031f93"/>
 	</game>
-	<game name="SoftSide v5n7 (1982-04)(SoftSide Publications)(US)">
-		<description>SoftSide v5n7 (1982-04)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v5n7 (1982-04)(SoftSide Publications)(US).wav" size="6144044" crc="098d3b73" md5="841539781a5cd16add16fe0e0aaf75e0" sha1="4147d4b8c4fee6abfae297e3d507ebff7960f89a"/>
+	<game name="SoftSide v05n09 (1982-06)(SoftSide Publications)(US)">
+		<description>SoftSide v05n09 (1982-06)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n09 (1982-06)(SoftSide Publications)(US).wav" size="5479212" crc="4c4363e4" md5="331e506855044d6dc56ea2d69d5d0fe8" sha1="f3cd6557ed709c13555b0cc67091fdbf40026104"/>
 	</game>
-	<game name="SoftSide v5n8 (1982-05)(SoftSide Publications)(US)">
-		<description>SoftSide v5n8 (1982-05)(SoftSide Publications)(US)</description>
-		<rom name="SoftSide v5n8 (1982-05)(SoftSide Publications)(US).wav" size="5369900" crc="fecbafe4" md5="a2d63f17ab26d25ce515fa36d69e9e06" sha1="d22ddcf09fb9d2793c9227f7abcdcfab46031f93"/>
+	<game name="SoftSide v05n10 (1982-07)(SoftSide Publications)(US)">
+		<description>SoftSide v05n10 (1982-07)(SoftSide Publications)(US)</description>
+		<rom name="SoftSide v05n10 (1982-07)(SoftSide Publications)(US).wav" size="3550764" crc="6ae8be1c" md5="237353f53465255ad136ccd2909ea822" sha1="b712888c96329b2c3c9a0c50b2bac98d4b784e5e"/>
 	</game>
 </datafile>


### PR DESCRIPTION
Identified "Issue 30" and "Issue 31" as volume 5 numbers 9 and 10
Changed format to v00n00 as the number is 1-12 to make sure they sort properly